### PR TITLE
pyenv-pipeline-plugin-17 Incorrect drive letter substitution on Windows

### DIFF
--- a/src/main/java/com/github/pyenvpipeline/jenkins/VirtualenvManager.java
+++ b/src/main/java/com/github/pyenvpipeline/jenkins/VirtualenvManager.java
@@ -336,7 +336,7 @@ public class VirtualenvManager implements Serializable {
 
     public String getRelativePythonEnvDirectory(String pythonInstallation){
         String postfix = pythonInstallation.replaceAll("/", "-")
-                .replaceFirst("C:\\\\", "")
+                .replaceFirst("[a-zA-Z]:\\\\", "")
                 .replaceAll("\\\\", "-");
 
         if (!postfix.startsWith("-")) {

--- a/src/test/java/com/github/pyenvpipeline/jenkins/steps/WithPythonEnvTest.java
+++ b/src/test/java/com/github/pyenvpipeline/jenkins/steps/WithPythonEnvTest.java
@@ -41,5 +41,7 @@ public class WithPythonEnvTest {
         Assert.assertEquals(".pyenv-foo-bar-blah-python", virtualenvManager.getRelativePythonEnvDirectory("/foo/bar/blah/python"));
         Assert.assertEquals(".pyenv-foo-bar-blah-python", virtualenvManager.getRelativePythonEnvDirectory("foo/bar/blah/python"));
         Assert.assertEquals(".pyenv-python3", virtualenvManager.getRelativePythonEnvDirectory("python3"));
+        Assert.assertEquals(".pyenv-Foo-Bar-python3", virtualenvManager.getRelativePythonEnvDirectory("c:\\Foo\\Bar\\python3"));
+        Assert.assertEquals(".pyenv-Foo-Bar-python3", virtualenvManager.getRelativePythonEnvDirectory("D:\\Foo\\Bar\\python3"));
     }
 }


### PR DESCRIPTION
Fixed regex stripping of Windows drive name to capture all letters, regardless of case. 