### PR TITLE
Unable to migrate out of pyenv-pipeline-plugin 1.0.4 to 2.0.0 #21

### DIFF
--- a/src/main/java/com/github/pyenvpipeline/jenkins/steps/PyEnvBatStep.java
+++ b/src/main/java/com/github/pyenvpipeline/jenkins/steps/PyEnvBatStep.java
@@ -1,0 +1,41 @@
+package com.github.pyenvpipeline.jenkins.steps;
+
+import hudson.Extension;
+import org.jenkinsci.plugins.durabletask.DurableTask;
+import org.jenkinsci.plugins.durabletask.WindowsBatchScript;
+import org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+@Deprecated
+public class PyEnvBatStep extends PyEnvDurableTaskBase {
+    private final String script;
+
+    @Override
+    protected DurableTask getDurableTask() {
+        return new WindowsBatchScript(script);
+    }
+
+    @DataBoundConstructor
+    public PyEnvBatStep(String script) {
+        if (script==null)
+            throw new IllegalArgumentException();
+        this.script = script;
+    }
+
+    public String getScript() {
+        return script;
+    }
+
+    @Extension
+    public static final class DescriptorImpl extends DurableTaskStep.DurableTaskStepDescriptor {
+
+        @Override public String getDisplayName() {
+            return "PyEnvVar Batch Script";
+        }
+
+
+        @Override public String getFunctionName() {
+            return "pybat";
+        }
+    }
+}

--- a/src/main/java/com/github/pyenvpipeline/jenkins/steps/PyEnvDurableTaskBase.java
+++ b/src/main/java/com/github/pyenvpipeline/jenkins/steps/PyEnvDurableTaskBase.java
@@ -1,0 +1,30 @@
+package com.github.pyenvpipeline.jenkins.steps;
+
+import org.jenkinsci.plugins.durabletask.DurableTask;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jenkinsci.plugins.workflow.steps.StepExecution;
+import org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep;
+
+import java.io.Serializable;
+
+// Deprecated as of v2.0.0.
+@Deprecated
+public abstract class PyEnvDurableTaskBase extends DurableTaskStep implements Serializable {
+    private DurableTask task;
+
+    @Override
+    protected DurableTask task() {
+        return task;
+    }
+
+    void setTask(DurableTask task) {
+        this.task = task;
+    }
+
+    abstract DurableTask getDurableTask();
+
+    @Override public StepExecution start(StepContext context) throws Exception {
+        setTask(getDurableTask());
+        return super.start(context);
+    }
+}

--- a/src/main/java/com/github/pyenvpipeline/jenkins/steps/PyEnvShellStep.java
+++ b/src/main/java/com/github/pyenvpipeline/jenkins/steps/PyEnvShellStep.java
@@ -1,0 +1,41 @@
+package com.github.pyenvpipeline.jenkins.steps;
+
+import hudson.Extension;
+import org.jenkinsci.plugins.durabletask.BourneShellScript;
+import org.jenkinsci.plugins.durabletask.DurableTask;
+import org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+@Deprecated
+public class PyEnvShellStep extends PyEnvDurableTaskBase {
+
+    private final String script;
+
+    @Override
+    protected DurableTask getDurableTask() {
+        return new BourneShellScript(script);
+    }
+
+    @DataBoundConstructor
+    public PyEnvShellStep(String script) {
+        if (script==null)
+            throw new IllegalArgumentException();
+        this.script = script;
+    }
+
+    public String getScript() {
+        return script;
+    }
+
+    @Extension
+    public static final class DescriptorImpl extends DurableTaskStep.DurableTaskStepDescriptor {
+
+        @Override public String getDisplayName() {
+            return "PyEnvVar Shell Script";
+        }
+
+        @Override public String getFunctionName() {
+            return "pysh";
+        }
+    }
+}

--- a/src/main/resources/com/github/pyenvpipeline/jenkins/steps/WithPythonEnvStep/help-script.html
+++ b/src/main/resources/com/github/pyenvpipeline/jenkins/steps/WithPythonEnvStep/help-script.html
@@ -2,5 +2,5 @@
     The series of commands to run within this particular virtualenv.
 </p>
 <p>
-    Intended to be used with the <code>pysh</code> and <code>pybat</code> steps.
+    Intended to be used with the <code>sh</code> and <code>bat</code> steps.
 </p>

--- a/src/main/resources/com/github/pyenvpipeline/jenkins/steps/WithPythonEnvStep/help.html
+++ b/src/main/resources/com/github/pyenvpipeline/jenkins/steps/WithPythonEnvStep/help.html
@@ -1,19 +1,23 @@
 <p>
-    Wraps a block in a Python virtualenv. Any <code>pysh</code> or <code>pybat</code> steps executed within the block,
-    are executed using the virtualenv specified
+    Wraps a block in a Python virtualenv. <code>pysh</code> or <code>pybat</code> steps are deprecated, and are simply
+    copies or <code>sh</code> and <code>bat</code> respectively.
 </p>
 <p>Example:</p>
 <pre><code>withPythonEnv('python3') {
-    pysh 'python --version'
+    sh 'python --version'
 }</code></pre>
 <p>
     The argument supplied to <code>withPythonEnv</code> is the name of the virtualenv to make available to any
-    <code>pysh</code> or <code>pybat</code> steps called within the block.
+    <code>sh</code> or <code>bat</code> steps called within the block.
 </p>
 <p>
     Initially, <code>withPythonEnv</code> tries to match the string passed to it to a tool name. Currently, this means
     examining the installed tools for ShiningPanada. If the string matches an installed ShiningPanda Python tool
     instance, the virtualenv within that block is generated from that ShiningPanda tool.
+</p>
+<p>
+    Next, we attempt to match the string against an existing virtualenv directory. If we can find an existing virtualenv
+    directory, we utilize that for the <code>withPythonEnv</code> block.
 </p>
 <p>
     Otherwise, the text is treated "as-is". You can pass "python" to use the default Python installation of the node


### PR DESCRIPTION
Added back in the original pysh and pybat steps, which at this point
are simple copies of sh and bat respectively.

Signed-off-by: Colin Starner <colin.starner@gmail.com>