### PR TITLE
Allow Windows path with Unix path separators after drive letter

### DIFF
--- a/src/main/java/com/github/pyenvpipeline/jenkins/AbstractVirtualenv.java
+++ b/src/main/java/com/github/pyenvpipeline/jenkins/AbstractVirtualenv.java
@@ -16,9 +16,8 @@ public abstract class AbstractVirtualenv implements Serializable {
 
     String getRelativePythonEnvDirectory(String pythonInstallation){
         String postfix = pythonInstallation.replaceAll("/", "-")
-                .replaceFirst("[a-zA-Z]:\\\\", "")
-                .replaceFirst("[a-zA-Z]:", "")
-                .replaceAll("\\\\", "-");
+                .replaceAll("\\\\", "-")
+                .replaceFirst("[a-zA-Z]:", "");
 
         if (!postfix.startsWith("-")) {
             postfix = "-" + postfix;

--- a/src/main/java/com/github/pyenvpipeline/jenkins/AbstractVirtualenv.java
+++ b/src/main/java/com/github/pyenvpipeline/jenkins/AbstractVirtualenv.java
@@ -17,6 +17,7 @@ public abstract class AbstractVirtualenv implements Serializable {
     String getRelativePythonEnvDirectory(String pythonInstallation){
         String postfix = pythonInstallation.replaceAll("/", "-")
                 .replaceFirst("[a-zA-Z]:\\\\", "")
+                .replaceFirst("[a-zA-Z]:", "")
                 .replaceAll("\\\\", "-");
 
         if (!postfix.startsWith("-")) {

--- a/src/test/java/com/github/pyenvpipeline/jenkins/steps/WithPythonEnvTest.java
+++ b/src/test/java/com/github/pyenvpipeline/jenkins/steps/WithPythonEnvTest.java
@@ -42,6 +42,6 @@ public class WithPythonEnvTest {
         Assert.assertEquals(".pyenv-foo-bar-blah-python", virtualenvManager.getRelativePythonEnvDirectory("foo/bar/blah/python"));
         Assert.assertEquals(".pyenv-python3", virtualenvManager.getRelativePythonEnvDirectory("python3"));
         Assert.assertEquals(".pyenv-Foo-Bar-python3", virtualenvManager.getRelativePythonEnvDirectory("c:\\Foo\\Bar\\python3"));
-        Assert.assertEquals(".pyenv-Foo-Bar-python3", virtualenvManager.getRelativePythonEnvDirectory("D:\\Foo\\Bar\\python3"));*/
+        Assert.assertEquals(".pyenv-Foo-Bar-python3", virtualenvManager.getRelativePythonEnvDirectory("D:/Foo/Bar/python3"));*/
     }
 }


### PR DESCRIPTION
Allow Windows path with Unix path separators after drive letter by handling drive letter without any path separator.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
